### PR TITLE
save vectors in parallel

### DIFF
--- a/src/fasttext.cc
+++ b/src/fasttext.cc
@@ -119,7 +119,7 @@ void FastText::getSubwordVector(Vector& vec, const std::string& subword) const {
 * output stream. A locking mechanism is used when writing to the stream
 * in order to avoid conflicts within a single line.
 */
-void FastText::saveVectorsParallel(const std::string& filename) {
+void FastText::saveVectors(const std::string& filename) {
   std::ofstream ofs(filename);
   if (!ofs.is_open()) {
     throw std::invalid_argument(
@@ -198,22 +198,6 @@ void FastText::streamVectorsParallelBatchLocked(int start_n, int end_n, std::ost
       ofs << out_string;
     }
   }
-}
-
-void FastText::saveVectors(const std::string& filename) {
-  std::ofstream ofs(filename);
-  if (!ofs.is_open()) {
-    throw std::invalid_argument(
-        filename + " cannot be opened for saving vectors!");
-  }
-  ofs << dict_->nwords() << " " << args_->dim << std::endl;
-  Vector vec(args_->dim);
-  for (int32_t i = 0; i < dict_->nwords(); i++) {
-    std::string word = dict_->getWord(i);
-    getWordVector(vec, word);
-    ofs << word << " " << vec << std::endl;
-  }
-  ofs.close();
 }
 
 void FastText::saveVectors() {

--- a/src/fasttext.cc
+++ b/src/fasttext.cc
@@ -138,7 +138,6 @@ void FastText::saveVectors(const std::string& filename) {
     int end_n = std::min(start_n + batch_size, num_words);
 
     // start one thread for each batch
-    // store the thread as a std::future
     futures.push_back(std::async(
       // start running asynchronously in a new thread right away
       std::launch::async,
@@ -151,7 +150,6 @@ void FastText::saveVectors(const std::string& filename) {
   }
 
   for (int i = 0; i < num_threads; i++) {
-    // block on each future, in order, until it is ready
     futures[i].wait();
   }
 

--- a/src/fasttext.cc
+++ b/src/fasttext.cc
@@ -123,7 +123,7 @@ void FastText::saveVectors(const std::string& filename) {
   std::ofstream ofs(filename);
   if (!ofs.is_open()) {
     throw std::invalid_argument(
-    filename + " cannot be opened for saving vectors!");
+        filename + " cannot be opened for saving vectors!");
   }
   ofs << dict_->nwords() << " " << args_->dim << std::endl;
 

--- a/src/fasttext.cc
+++ b/src/fasttext.cc
@@ -11,9 +11,9 @@
 #include "quantmatrix.h"
 
 #include <algorithm>
+#include <future>
 #include <iomanip>
 #include <iostream>
-#include <future>
 #include <numeric>
 #include <sstream>
 #include <stdexcept>

--- a/src/fasttext.cc
+++ b/src/fasttext.cc
@@ -141,7 +141,6 @@ void FastText::saveVectors(const std::string& filename) {
     // store the thread as a std::future
     futures.push_back(std::async(
       // start running asynchronously in a new thread right away
-      // there is *not* automatic thread pooling here
       std::launch::async,
       &FastText::streamVectorsParallelBatchLocked,
       this,

--- a/src/fasttext.h
+++ b/src/fasttext.h
@@ -100,7 +100,6 @@ class FastText {
   std::shared_ptr<const DenseMatrix> getOutputMatrix() const;
 
   void saveVectors(const std::string& filename);
-  void saveVectorsParallel(const std::string& filename);
 
   void saveModel(const std::string& filename);
 

--- a/src/fasttext.h
+++ b/src/fasttext.h
@@ -14,6 +14,7 @@
 #include <chrono>
 #include <iostream>
 #include <memory>
+#include <mutex>
 #include <queue>
 #include <set>
 #include <tuple>
@@ -46,6 +47,7 @@ class FastText {
   std::chrono::steady_clock::time_point start_;
   void signModel(std::ostream&);
   bool checkModel(std::istream&);
+  void streamVectorsParallelBatchLocked(int, int, std::ostream&, std::mutex&) const;
   void startThreads();
   void addInputVector(Vector&, int32_t) const;
   void trainThread(int32_t);
@@ -98,6 +100,7 @@ class FastText {
   std::shared_ptr<const DenseMatrix> getOutputMatrix() const;
 
   void saveVectors(const std::string& filename);
+  void saveVectorsParallel(const std::string& filename);
 
   void saveModel(const std::string& filename);
 


### PR DESCRIPTION
System info:
```sh
$ lsmem
RANGE                                  SIZE  STATE REMOVABLE  BLOCK
0x0000000000000000-0x000000004fffffff  1.3G online        no    0-9
0x0000000100000000-0x00000004a7ffffff 14.6G online        no 32-148

Memory block size:       128M
Total online memory:    15.9G
Total offline memory:      0B
$ lscpu
Architecture:        x86_64
CPU op-mode(s):      32-bit, 64-bit
Byte Order:          Little Endian
Address sizes:       39 bits physical, 48 bits virtual
CPU(s):              8
On-line CPU(s) list: 0-7
Thread(s) per core:  2
Core(s) per socket:  4
Socket(s):           1
NUMA node(s):        1
Vendor ID:           GenuineIntel
CPU family:          6
Model:               142
Model name:          Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz
Stepping:            10
CPU MHz:             600.024
CPU max MHz:         4200.0000
CPU min MHz:         400.0000
BogoMIPS:            4224.00
Virtualization:      VT-x
L1d cache:           32K
L1i cache:           32K
L2 cache:            256K
L3 cache:            8192K
NUMA node0 CPU(s):   0-7
Flags:               fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf tsc_known_freq pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb invpcid_single pti ssbd ibrs ibpb stibp tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid rtm mpx rdseed adx smap clflushopt intel_pt xsaveopt xsavec xgetbv1 xsaves dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp flush_l1d
```

With binary built from master branch:
```sh
$ time ./fasttext-master supervised -input data/amazon_review_polarity_csv/train.csv -output out-single                                                                                  
Read 282M words
Number of words:  6735845
Number of labels: 0
Progress: 100.0% words/sec/thread: 2829461 lr:  0.000000 loss:      -nan ETA:   0h 0m

real    7m39.323s
user    11m50.848s
sys     0m25.348s
```

With binary built using parallel `saveVectors`
```sh
$ time ./fasttext supervised -input data/amazon_review_polarity_csv/train.csv -output out-parallel                                                                                       
Read 282M words
Number of words:  6735845
Number of labels: 0
Progress: 100.0% words/sec/thread: 2754298 lr:  0.000000 loss:      -nan ETA:   0h 0m

real    3m21.412s
user    17m18.682s
sys     0m18.058s
```

Validated equal outputs with:
```sh
$ wc -l out-parallel.vec
6735846 out-parallel.vec
$ wc -l out-single.vec
6735846 out-single.vec
$ cat out-single.vec | sort > out-single.vec.sorted
$ cat out-parallel.vec | sort > out-parallel.vec.sorted
$ cmp out-single.vec.sorted out-parallel.vec.sorted 
```